### PR TITLE
Admin and User Dashboards

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -6,10 +6,11 @@ class Role(enum.Enum):
     student = "student"
     admin = "admin"
 
-admin_students = db.Table("admin_students",
-    db.Column("admin_id", db.Integer, db.ForeignKey("user.id"), nullable=False),
-    db.Column("student_id", db.Integer, db.ForeignKey("user.id"), nullable=False),
-    db.Column("list_id", db.Integer, db.ForeignKey("todo_list.id"), nullable=True)
+admin_students = db.Table(
+    "admin_students",
+    db.Column("admin_id", db.Integer, db.ForeignKey("user.id"), primary_key=True),
+    db.Column("student_id", db.Integer, db.ForeignKey("user.id"), primary_key=True),
+    db.Column("list_id", db.Integer, db.ForeignKey("todo_list.id"), nullable=True),
 )
 
 class User(db.Model):

--- a/backend/routes/admin.py
+++ b/backend/routes/admin.py
@@ -1,19 +1,38 @@
-from permissions import admin_required, get_admin_student_relationship
 from flask import Blueprint, request, jsonify
 from flask_jwt_extended import get_jwt_identity, jwt_required
+from sqlalchemy import select, and_
+from permissions import admin_required
 from config import db
-from models import User, Role, TodoList, admin_students
+from models import User, Role, TodoList, admin_students, Task
 
 admin_bp = Blueprint("admin", __name__)
+
+
+def _admin_student_link(admin_id: int, student_id: int):
+    return db.session.execute(
+        select(admin_students).where(
+            and_(
+                admin_students.c.admin_id == admin_id,
+                admin_students.c.student_id == student_id,
+            )
+        )
+    ).first()
 
 @admin_bp.route("/admin/users", methods=["GET"])
 @jwt_required()
 @admin_required
 def get_users():
     admin_id = int(get_jwt_identity())
-    admin = db.session.get(User, admin_id)
-    users = admin.students
-    return jsonify([user.to_json() for user in users]), 200
+
+    rows = db.session.execute(
+        select(User)
+        .join(admin_students, admin_students.c.student_id == User.id)
+        .where(admin_students.c.admin_id == admin_id)
+        .order_by(User.username.asc())
+    ).scalars().all()
+
+    return jsonify([u.to_json() for u in rows]), 200
+
 
 @admin_bp.route("/admin/users/<int:id>", methods=["GET"])
 @jwt_required()
@@ -25,17 +44,17 @@ def get_user(id):
     if not user:
         return jsonify({"ERROR": "User not found"}), 404
 
-    relationship = get_admin_student_relationship(admin_id, user.id)
-    if not relationship:
+    if not _admin_student_link(admin_id, user.id):
         return jsonify({"ERROR": "Forbidden"}), 403
 
     return jsonify(user.to_json()), 200
+
 
 @admin_bp.route("/admin/users/<int:id>/assign", methods=["PUT"])
 @jwt_required()
 @admin_required
 def assign_student(id):
-    current_user_id = int(get_jwt_identity())
+    admin_id = int(get_jwt_identity())
     user = db.session.get(User, id)
 
     if not user:
@@ -43,11 +62,12 @@ def assign_student(id):
     if user.is_admin():
         return jsonify({"ERROR": "Cannot assign an admin as a student"}), 400
 
-    existing = get_admin_student_relationship(current_user_id, user.id)
+    # check only this admin<->student pair
+    existing = _admin_student_link(admin_id, user.id)
     if existing:
         return jsonify({"ERROR": "Student already assigned to this admin"}), 400
 
-    admin = db.session.get(User, current_user_id)
+    admin = db.session.get(User, admin_id)
     dedicated_list = TodoList(
         name=f"Tasks from {admin.username}",
         description=f"Tasks assigned by {admin.username}",
@@ -59,7 +79,7 @@ def assign_student(id):
 
     db.session.execute(
         admin_students.insert().values(
-            admin_id=current_user_id,
+            admin_id=admin_id,
             student_id=user.id,
             list_id=dedicated_list.id
         )
@@ -67,3 +87,66 @@ def assign_student(id):
     db.session.commit()
 
     return jsonify(user.to_json()), 200
+
+
+@admin_bp.route("/admin/users/<int:id>/assign", methods=["DELETE"])
+@jwt_required()
+@admin_required
+def unassign_student(id):
+    admin_id = int(get_jwt_identity())
+    user = db.session.get(User, id)
+
+    if not user:
+        return jsonify({"ERROR": "User not found"}), 404
+    if user.is_admin():
+        return jsonify({"ERROR": "Cannot unassign an admin"}), 400
+
+    relationship = _admin_student_link(admin_id, user.id)
+    if not relationship:
+        return jsonify({"ERROR": "Student is not assigned to this admin"}), 404
+
+    link = relationship._mapping
+    list_id = link.get("list_id")
+
+    if list_id:
+        dedicated_list = db.session.get(TodoList, list_id)
+        if dedicated_list:
+            Task.query.filter_by(todo_list_id=dedicated_list.id).delete(synchronize_session=False)
+            db.session.delete(dedicated_list)
+
+    db.session.execute(
+        admin_students.delete().where(
+            admin_students.c.admin_id == admin_id,
+            admin_students.c.student_id == user.id
+        )
+    )
+    db.session.commit()
+
+    return jsonify(user.to_json()), 200
+
+
+@admin_bp.route("/admin/students", methods=["GET"])
+@jwt_required()
+@admin_required
+def get_students_for_assignment():
+    admin_id = int(get_jwt_identity())
+    q = (request.args.get("q") or "").strip()
+
+    query = User.query.filter(User.role == Role.student)
+    if q:
+        query = query.filter(User.username.ilike(f"%{q}%"))
+    students = query.order_by(User.username.asc()).all()
+
+    my_ids = {
+        r[0] for r in db.session.execute(
+            select(admin_students.c.student_id).where(admin_students.c.admin_id == admin_id)
+        ).all()
+    }
+
+    out = []
+    for s in students:
+        j = s.to_json()
+        j["assigned_to_me"] = s.id in my_ids
+        out.append(j)
+
+    return jsonify(out), 200

--- a/backend/routes/lists.py
+++ b/backend/routes/lists.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, request, jsonify
 from flask_jwt_extended import get_jwt_identity, jwt_required
 from config import db
-from models import TodoList, Task, User, TaskPriority, TaskStatus
+from models import TodoList, Task, User, TaskPriority, TaskStatus, admin_students
 from datetime import datetime
 from permissions import admin_required, get_admin_student_relationship, is_assigned_task
 
@@ -40,6 +40,34 @@ def get_all_lists():
     lists = TodoList.query.filter_by(user_id=user_id).all()
 
     return jsonify([todo_list.to_json() for todo_list in lists]), 200
+
+@todo_bp.route("/lists/assigned", methods=["GET"])
+@jwt_required()
+def get_assigned_lists():
+    user_id = int(get_jwt_identity())
+
+    rows = (
+        db.session.query(
+            TodoList,
+            User.id.label("admin_id"),
+            User.username.label("admin_username"),
+        )
+        .join(admin_students, admin_students.c.list_id == TodoList.id)
+        .join(User, User.id == admin_students.c.admin_id)
+        .filter(admin_students.c.student_id == user_id)
+        .all()
+    )
+
+    result = []
+    for todo_list, admin_id, admin_username in rows:
+        item = todo_list.to_json()
+        item["assigned_by"] = {
+            "id": admin_id,
+            "username": admin_username,
+        }
+        result.append(item)
+
+    return jsonify(result), 200
 
 @todo_bp.route("/lists/<int:id>", methods=["GET"])
 @jwt_required()
@@ -195,8 +223,14 @@ def edit_task(list_id, task_id):
         return jsonify({"ERROR": "Task not found"}), 404
     if task.todo_list_id != list_id:
         return jsonify({"ERROR": "Task does not belong to list"}), 400
-    if is_assigned_task(task) and not current_user.is_admin():
-        return jsonify({"ERROR": "Cannot modify admin-assigned tasks"}), 403
+
+    assigned_task = is_assigned_task(task)
+    is_admin = current_user.is_admin()
+
+    if assigned_task and not is_admin:
+        non_status_fields = {"title", "description", "due_date", "priority", "todo_list_id"}
+        if any(field in data for field in non_status_fields):
+            return jsonify({"ERROR": "Can only change status for admin-assigned tasks"}), 403
 
     if data.get("title") is not None:
         task.title = data["title"]
@@ -222,6 +256,12 @@ def edit_task(list_id, task_id):
             return jsonify({"ERROR": "Invalid priority"}), 400
         else:
             task.priority = priority
+
+    if data.get("status") is not None:
+        try:
+            task.status = TaskStatus(data["status"])
+        except ValueError:
+            return jsonify({"ERROR": "Invalid status"}), 400
     
     todo_list_id = data.get("todo_list_id")
     if todo_list_id:
@@ -256,8 +296,10 @@ def delete_task(list_id, task_id):
         return jsonify({"ERROR": "Task not found"}), 404
     if task.todo_list_id != list_id:
         return jsonify({"ERROR": "Task does not belong to list"}), 400
+
     if is_assigned_task(task) and not current_user.is_admin():
-        return jsonify({"ERROR": "Cannot modify admin-assigned tasks"}), 403
+        if task.status != TaskStatus.complete:
+            return jsonify({"ERROR": "Admin-assigned tasks can only be deleted when complete"}), 403
 
     db.session.delete(task)
     db.session.commit()

--- a/backend/routes/lists.py
+++ b/backend/routes/lists.py
@@ -330,6 +330,7 @@ def task_complete(list_id, task_id):
 
     return jsonify(task.to_json()), 200
 
+@todo_bp.route("/admin/tasks", methods=["POST"])
 @todo_bp.route("/tasks", methods=["POST"])
 @jwt_required()
 @admin_required
@@ -339,21 +340,6 @@ def assign_task():
         return jsonify({"ERROR": "No data provided"}), 400
 
     admin_id = int(get_jwt_identity())
-
-    if data.get("user_id") is None:
-        return jsonify({"ERROR": "user_id is required"}), 400
-
-    assigned_user = db.session.get(User, int(data["user_id"]))
-    if not assigned_user:
-        return jsonify({"ERROR": "Assigned user not found"}), 404
-    
-    relationship = get_admin_student_relationship(admin_id, assigned_user.id)
-    if not relationship:
-        return jsonify({"ERROR": "Forbidden"}), 403
-
-    dedicated_list = db.session.get(TodoList, relationship.list_id)
-    if not dedicated_list:
-        return jsonify({"ERROR": "No dedicated list found for this student"}), 404
 
     if not data.get("title"):
         return jsonify({"ERROR": "Task must have a title"}), 400
@@ -373,18 +359,64 @@ def assign_task():
         except ValueError:
             return jsonify({"ERROR": "Invalid priority"}), 400
 
-    new_task = Task(
-        title=data["title"],
-        description=data.get("description"),
-        due_date=due,
-        status=TaskStatus.incomplete,
-        priority=priority,
-        user_id=assigned_user.id,
-        todo_list_id=dedicated_list.id
-    )
+    target_ids = set()
+    if data.get("all_students") is True:
+        rows = (
+            db.session.query(admin_students.c.student_id)
+            .filter(admin_students.c.admin_id == admin_id)
+            .all()
+        )
+        target_ids = {int(r.student_id) for r in rows}
+    elif isinstance(data.get("user_ids"), list):
+        try:
+            target_ids = {int(x) for x in data["user_ids"]}
+        except (TypeError, ValueError):
+            return jsonify({"ERROR": "user_ids must be a list of integers"}), 400
+    elif data.get("user_id") is not None:
+        try:
+            target_ids = {int(data["user_id"])}
+        except (TypeError, ValueError):
+            return jsonify({"ERROR": "user_id must be an integer"}), 400
+    else:
+        return jsonify({"ERROR": "Provide one of: user_id, user_ids, all_students=true"}), 400
 
-    db.session.add(new_task)
+    if not target_ids:
+        return jsonify({"ERROR": "No students selected"}), 400
+
+    created_tasks = []
+
+    for student_id in target_ids:
+        assigned_user = db.session.get(User, student_id)
+        if not assigned_user:
+            continue
+
+        relationship = get_admin_student_relationship(admin_id, assigned_user.id)
+        if not relationship:
+            continue
+
+        dedicated_list = db.session.get(TodoList, relationship.list_id)
+        if not dedicated_list:
+            continue
+
+        new_task = Task(
+            title=data["title"],
+            description=data.get("description"),
+            due_date=due,
+            status=TaskStatus.incomplete,
+            priority=priority,
+            user_id=assigned_user.id,
+            todo_list_id=dedicated_list.id
+        )
+        db.session.add(new_task)
+        created_tasks.append(new_task)
+
+    if not created_tasks:
+        return jsonify({"ERROR": "No valid assigned students found"}), 400
+
     db.session.commit()
 
-    return jsonify(new_task.to_json()), 201
+    payload = [t.to_json() for t in created_tasks]
+    if len(payload) == 1:
+        return jsonify(payload[0]), 201
+    return jsonify({"count": len(payload), "tasks": payload}), 201
 #endregion

--- a/backend/seed.py
+++ b/backend/seed.py
@@ -1,0 +1,50 @@
+from config import create_app, db
+from models import User, Role, TodoList
+from werkzeug.security import generate_password_hash
+
+
+def make_user(username, email, raw_password, role):
+    user = User(
+        username=username,
+        email=email,
+        password=generate_password_hash(raw_password),
+        role=role,
+    )
+    db.session.add(user)
+    db.session.flush()  # get user.id
+
+    db.session.add(
+        TodoList(
+            is_default=True,
+            name="Tasks",
+            description="Default list for standalone tasks",
+            user_id=user.id,
+        )
+    )
+    return user
+
+
+def seed():
+    app = create_app()
+
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+
+        # 2 admins
+        make_user("admin1", "admin1@example.com", "admin123", Role.admin)
+        make_user("admin2", "admin2@example.com", "admin456", Role.admin)
+
+        # required student
+        make_user("user", "user@example.com", "user123", Role.student)
+
+        # 9 more students (total 10 students)
+        for i in range(2, 11):
+            make_user(f"user{i}", f"user{i}@example.com", f"user{i}123", Role.student)
+
+        db.session.commit()
+        print("Seed complete.")
+
+
+if __name__ == "__main__":
+    seed()

--- a/frontend/src/AdminDashboard.jsx
+++ b/frontend/src/AdminDashboard.jsx
@@ -1,0 +1,293 @@
+import { useEffect, useState } from "react"
+import apiCall from "./api/client"
+import "./styles/admin-dashboard.css"
+
+const BG = "/background-faded-blue.avif"
+
+export default function AdminDashboard() {
+  const [taskTitle, setTaskTitle] = useState("")
+  const [taskDescription, setTaskDescription] = useState("")
+  const [taskDue, setTaskDue] = useState("")
+  const [taskPriority, setTaskPriority] = useState("low")
+  const [taskSaving, setTaskSaving] = useState(false)
+
+  const [reminderText, setReminderText] = useState("")
+  const [reminderDescription, setReminderDescription] = useState("")
+  const [reminderAt, setReminderAt] = useState("")
+  const [reminderSaving, setReminderSaving] = useState(false)
+
+  const [users, setUsers] = useState([])
+
+  const [targetMode, setTargetMode] = useState("single")
+  const [selectedUserId, setSelectedUserId] = useState("")
+  const [selectedUserIds, setSelectedUserIds] = useState([])
+
+  const [reminderTargetMode, setReminderTargetMode] = useState("single")
+  const [selectedReminderUserId, setSelectedReminderUserId] = useState("")
+  const [selectedReminderUserIds, setSelectedReminderUserIds] = useState([])
+
+  const [msg, setMsg] = useState("")
+
+  useEffect(() => {
+    const loadMyUsers = async () => {
+      try {
+        const res = await apiCall("/admin/users", { method: "GET" })
+        const data = await res.json().catch(() => [])
+        if (!res.ok) throw new Error()
+
+        const myUsers = Array.isArray(data) ? data : []
+        setUsers(myUsers)
+
+        if (myUsers.length > 0) {
+          const firstId = String(myUsers[0].id)
+          setSelectedUserId(firstId)
+          setSelectedReminderUserId(firstId)
+        } else {
+          setSelectedUserId("")
+          setSelectedReminderUserId("")
+        }
+
+        setSelectedUserIds([])
+        setSelectedReminderUserIds([])
+      } catch {
+        setUsers([])
+        setSelectedUserId("")
+        setSelectedReminderUserId("")
+        setSelectedUserIds([])
+        setSelectedReminderUserIds([])
+      }
+    }
+
+    loadMyUsers()
+  }, [])
+
+  const toggleUser = (id) => {
+    setSelectedUserIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    )
+  }
+
+  const toggleReminderUser = (id) => {
+    setSelectedReminderUserIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    )
+  }
+
+  const quickAddTask = async (e) => {
+    e.preventDefault()
+    if (!taskTitle.trim()) return
+
+    setTaskSaving(true)
+    setMsg("")
+
+    try {
+      let targetPayload = {}
+
+      if (targetMode === "all") {
+        targetPayload = { all_students: true }
+      } else if (targetMode === "multi") {
+        if (selectedUserIds.length === 0) throw new Error("Select at least one user")
+        targetPayload = { user_ids: selectedUserIds }
+      } else {
+        if (!selectedUserId) throw new Error("Select a user")
+        targetPayload = { user_id: Number(selectedUserId) }
+      }
+
+      const res = await apiCall("/tasks", {
+        method: "POST",
+        body: JSON.stringify({
+          title: taskTitle.trim(),
+          description: taskDescription.trim() || "",
+          due_date: taskDue || null,
+          priority: taskPriority,
+          ...targetPayload,
+        }),
+      })
+
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(data.ERROR || "Failed to add task")
+
+      setTaskTitle("")
+      setTaskDescription("")
+      setTaskDue("")
+      setTaskPriority("low")
+      setSelectedUserIds([])
+      setMsg("Task added.")
+    } catch (err) {
+      setMsg(err.message || "Failed to add task")
+    } finally {
+      setTaskSaving(false)
+    }
+  }
+
+  const quickAddReminder = async (e) => {
+    e.preventDefault()
+    if (!reminderText.trim()) return
+    if (!reminderAt) {
+      setMsg("Reminder date/time is required.")
+      return
+    }
+
+    setReminderSaving(true)
+    setMsg("")
+
+    try {
+      let recipients = []
+
+      if (reminderTargetMode === "all") {
+        recipients = users.map((u) => u.id)
+        if (!recipients.length) throw new Error("No assigned users found")
+      } else if (reminderTargetMode === "multi") {
+        if (selectedReminderUserIds.length === 0) throw new Error("Select at least one user")
+        recipients = selectedReminderUserIds
+      } else {
+        if (!selectedReminderUserId) throw new Error("Select a user")
+        recipients = [Number(selectedReminderUserId)]
+      }
+
+      const res = await apiCall("/reminders", {
+        method: "POST",
+        body: JSON.stringify({
+          title: reminderText.trim(),
+          description: reminderDescription.trim() || "",
+          due_date: reminderAt,
+          recipients,
+        }),
+      })
+
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(data.ERROR || "Failed to add reminder")
+
+      setReminderText("")
+      setReminderDescription("")
+      setReminderAt("")
+      setSelectedReminderUserIds([])
+      setMsg("Reminder added.")
+    } catch (err) {
+      setMsg(err.message || "Failed to add reminder")
+    } finally {
+      setReminderSaving(false)
+    }
+  }
+
+  return (
+    <main className="ad-page" style={{ backgroundImage: `url(${BG})` }}>
+      <div className="ad-shell">
+        <div className="ad-header">Admin Dashboard</div>
+
+        <section className="ad-grid">
+          <article className="ad-card">
+            <h3 className="ad-card-title">Task</h3>
+
+            <form className="ad-form" onSubmit={quickAddTask}>
+              <div className="ad-target-row">
+                <label><input type="radio" name="taskTargetMode" checked={targetMode === "single"} onChange={() => setTargetMode("single")} />One</label>
+                <label><input type="radio" name="taskTargetMode" checked={targetMode === "multi"} onChange={() => setTargetMode("multi")} />Many</label>
+                <label><input type="radio" name="taskTargetMode" checked={targetMode === "all"} onChange={() => setTargetMode("all")} />All</label>
+              </div>
+
+              {targetMode === "single" && (
+                <select className="ad-input" value={selectedUserId} onChange={(e) => setSelectedUserId(e.target.value)}>
+                  <option value="">Select user</option>
+                  {users.map((u) => <option key={u.id} value={u.id}>{u.username}</option>)}
+                </select>
+              )}
+
+              {targetMode === "multi" && (
+                <div className="ad-student-checklist">
+                  {users.map((u) => (
+                    <label key={u.id}>
+                      <input type="checkbox" checked={selectedUserIds.includes(u.id)} onChange={() => toggleUser(u.id)} />
+                      {u.username}
+                    </label>
+                  ))}
+                </div>
+              )}
+
+              <input className="ad-input" placeholder="Quick add task title" value={taskTitle} onChange={(e) => setTaskTitle(e.target.value)} />
+              <textarea
+                className="ad-input"
+                rows={3}
+                placeholder="Task description (optional)"
+                value={taskDescription}
+                onChange={(e) => setTaskDescription(e.target.value)}
+              />
+              <input className="ad-input" type="datetime-local" value={taskDue} onChange={(e) => setTaskDue(e.target.value)} />
+                <select
+                className="ad-input"
+                value={taskPriority}
+                onChange={(e) => setTaskPriority(e.target.value)}
+              >
+                <option value="low">Low</option>
+                <option value="medium">Medium</option>
+                <option value="high">High</option>
+              </select>
+              <button className="ad-btn" type="submit" disabled={taskSaving}>{taskSaving ? "Saving..." : "Add Task"}</button>
+            </form>
+          </article>
+
+          <article className="ad-card">
+            <h3 className="ad-card-title">Reminder</h3>
+
+            <form className="ad-form" onSubmit={quickAddReminder}>
+              <div className="ad-target-row">
+                <label><input type="radio" name="reminderTargetMode" checked={reminderTargetMode === "single"} onChange={() => setReminderTargetMode("single")} />One</label>
+                <label><input type="radio" name="reminderTargetMode" checked={reminderTargetMode === "multi"} onChange={() => setReminderTargetMode("multi")} />Many</label>
+                <label><input type="radio" name="reminderTargetMode" checked={reminderTargetMode === "all"} onChange={() => setReminderTargetMode("all")} />All</label>
+              </div>
+
+              {reminderTargetMode === "single" && (
+                <select className="ad-input" value={selectedReminderUserId} onChange={(e) => setSelectedReminderUserId(e.target.value)}>
+                  <option value="">Select user</option>
+                  {users.map((u) => <option key={u.id} value={u.id}>{u.username}</option>)}
+                </select>
+              )}
+
+              {reminderTargetMode === "multi" && (
+                <div className="ad-student-checklist">
+                  {users.map((u) => (
+                    <label key={u.id}>
+                      <input type="checkbox" checked={selectedReminderUserIds.includes(u.id)} onChange={() => toggleReminderUser(u.id)} />
+                      {u.username}
+                    </label>
+                  ))}
+                </div>
+              )}
+
+              <input className="ad-input" placeholder="Quick add reminder title" value={reminderText} onChange={(e) => setReminderText(e.target.value)} />
+              <textarea
+                className="ad-input"
+                rows={3}
+                placeholder="Reminder description (optional)"
+                value={reminderDescription}
+                onChange={(e) => setReminderDescription(e.target.value)}
+              />
+              <input className="ad-input" type="datetime-local" value={reminderAt} onChange={(e) => setReminderAt(e.target.value)} />
+              <button className="ad-btn" type="submit" disabled={reminderSaving}>{reminderSaving ? "Saving..." : "Add Reminder"}</button>
+            </form>
+          </article>
+        </section>
+
+        <section className="ad-grid ad-grid-single">
+          <article className="ad-card">
+            <h3 className="ad-card-title">My Users</h3>
+            {users.length === 0 ? (
+              <p className="ad-msg">No assigned users.</p>
+            ) : (
+              <ul className="ad-students-list">
+                {users.map((u) => (
+                  <li key={u.id} className="ad-student-item">
+                    <strong>{u.username}</strong>
+                    <span>{u.email || "No email"}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </article>
+        </section>
+
+        {msg ? <p className="ad-msg">{msg}</p> : null}
+      </div>
+    </main>
+  )
+}

--- a/frontend/src/AdminStudents.jsx
+++ b/frontend/src/AdminStudents.jsx
@@ -1,0 +1,102 @@
+import { useEffect, useState } from "react"
+import apiCall from "./api/client"
+import "./styles/admin-students.css"
+
+const BG = "/background-faded-blue.avif"
+
+export default function AdminStudents() {
+  const [q, setQ] = useState("")
+  const [students, setStudents] = useState([])
+  const [loading, setLoading] = useState(false)
+  const [msg, setMsg] = useState("")
+
+  const loadStudents = async (search = "") => {
+    setLoading(true)
+    setMsg("")
+    try {
+      const res = await apiCall(`/admin/students?q=${encodeURIComponent(search)}`, { method: "GET" })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.ERROR || "Failed to load users")
+      setStudents(Array.isArray(data) ? data : [])
+    } catch (e) {
+      setMsg(e.message || "Failed to load students")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadStudents("")
+  }, [])
+
+  const assignStudent = async (id) => {
+    setMsg("")
+    try {
+      const res = await apiCall(`/admin/users/${id}/assign`, { method: "PUT" })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(data.ERROR || "Failed to assign user")
+      await loadStudents(q)
+      setMsg("Student assigned.")
+    } catch (e) {
+      setMsg(e.message || "Failed to assign student")
+    }
+  }
+  const unassignStudent = async (id) => {
+    setMsg("")
+    try {
+      const res = await apiCall(`/admin/users/${id}/assign`, { method: "DELETE" })
+      const data = await res.json().catch(() => ({}))
+      if (!res.ok) throw new Error(data.ERROR || "Failed to unassign user")
+      await loadStudents(q)
+      setMsg("Student unassigned.")
+    } catch (e) {
+      setMsg(e.message || "Failed to unassign student")
+    }
+  }
+
+  return (
+    <main className="as-page" style={{ backgroundImage: `url(${BG})` }}>
+      <div className="as-shell">
+        <div className="as-header-top">Manage Users</div>
+
+        <section className="as-card">
+          <div className="as-search-row">
+            <input
+              className="as-input"
+              value={q}
+              onChange={(e) => setQ(e.target.value)}
+              placeholder="Search by username..."
+            />
+            <button className="as-btn" onClick={() => loadStudents(q)}>
+              Search
+            </button>
+          </div>
+
+          {loading ? <p className="as-note">Loading...</p> : null}
+          {msg ? <p className="as-note">{msg}</p> : null}
+
+          <ul className="as-list">
+        {students.map((s) => (
+        <li key={s.id} className="as-item">
+            <div>
+            <strong>{s.username}</strong>
+            <div className="as-sub">{s.email || "no email"}</div>
+            </div>
+
+            {s.assigned_to_me ? (
+            <button className="as-btn as-btn-danger" onClick={() => unassignStudent(s.id)}>
+                Unassign
+            </button>
+            ) : (
+            <button className="as-btn" onClick={() => assignStudent(s.id)}>
+                Assign
+            </button>
+            )}
+        </li>
+        ))}
+          </ul>
+        </section>
+      </div>
+    </main>
+  )
+}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,49 +1,134 @@
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom"
 import LoginPage from "./LogIn"
-import StudentDashboard from "./StudentDashboard"
 import RegisterPage from "./Register"
-import MoodEntriesPage from "./Journal"
 import Header from "./components/Header"
 
+import StudentDashboard from "./StudentDashboard"
+import MoodEntriesPage from "./Journal"
+
+import AdminDashboard from "./AdminDashboard"
+import AdminStudents from "./AdminStudents"
+// import AdminTasksPage from "./AdminTasksPage"
+// import AdminRemindersPage from "./AdminRemindersPage"
+// import AdminListsPage from "./AdminListsPage"
+
 function ProtectedRoute({ children }) {
-    const token = localStorage.getItem("token")
-    if (!token) return <Navigate to="/login" />
-    return children
+  const token = localStorage.getItem("token")
+  if (!token) return <Navigate to="/login" />
+  return children
+}
+
+function StudentRoute({ children }) {
+  const token = localStorage.getItem("token")
+  const user = JSON.parse(localStorage.getItem("user") || "{}")
+  if (!token) return <Navigate to="/login" />
+  if (String(user?.role || "").toLowerCase() === "admin") return <Navigate to="/admin/dashboard" />
+  return children
+}
+
+function AdminRoute({ children }) {
+  const token = localStorage.getItem("token")
+  const user = JSON.parse(localStorage.getItem("user") || "{}")
+  if (!token) return <Navigate to="/login" />
+  if (String(user?.role || "").toLowerCase() !== "admin") return <Navigate to="/dashboard" />
+  return children
 }
 
 function App() {
-    return (
-        <BrowserRouter>
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/register" element={<RegisterPage />} />
 
-            <Routes>
-                <Route path="/login" element={<LoginPage />} />
-                <Route path="/register" element={<RegisterPage />} />
+        <Route
+          path="/dashboard"
+          element={
+            <StudentRoute>
+              <>
+                <Header />
+                <StudentDashboard />
+              </>
+            </StudentRoute>
+          }
+        />
 
-                <Route path="/dashboard" element={
-                    <ProtectedRoute>
-                        <>
-                            <Header />
-                            <StudentDashboard />
-                        </>
-                    </ProtectedRoute>
-                } />
+        <Route
+          path="/journal"
+          element={
+            <StudentRoute>
+              <>
+                <Header />
+                <MoodEntriesPage />
+              </>
+            </StudentRoute>
+          }
+        />
 
-                <Route
-                    path="/journal"
-                    element={
-                        <ProtectedRoute>
-                            <>
-                                <Header />
-                                <MoodEntriesPage />
-                            </>
-                        </ProtectedRoute>
-                    }
-                />
+        <Route
+          path="/admin/dashboard"
+          element={
+            <AdminRoute>
+              <>
+                <Header />
+                <AdminDashboard />
+              </>
+            </AdminRoute>
+          }
+        />
 
-                <Route path="/" element={<Navigate to="/login" />} />
-            </Routes>
-        </BrowserRouter>
-    )
+        {/* <Route
+          path="/admin/tasks"
+          element={
+            <AdminRoute>
+              <>
+                <Header />
+                <AdminTasksPage />
+              </>
+            </AdminRoute>
+          }
+        />
+
+        <Route
+          path="/admin/reminders"
+          element={
+            <AdminRoute>
+              <>
+                <Header />
+                <AdminRemindersPage />
+              </>
+            </AdminRoute>
+          }
+        /> */}
+
+        <Route
+          path="/admin/students"
+          element={
+            <AdminRoute>
+              <>
+                <Header />
+                <AdminStudents />
+              </>
+            </AdminRoute>
+          }
+        />
+
+        {/* <Route
+          path="/admin/lists"
+          element={
+            <AdminRoute>
+              <>
+                <Header />
+                <AdminListsPage />
+              </>
+            </AdminRoute>
+          }
+        /> */}
+
+        <Route path="/" element={<Navigate to="/login" />} />
+      </Routes>
+    </BrowserRouter>
+  )
 }
 
 export default App

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom"
 import LoginPage from "./LogIn"
+import StudentDashboard from "./StudentDashboard"
 import RegisterPage from "./Register"
 import MoodEntriesPage from "./Journal"
 import Header from "./components/Header"
@@ -22,7 +23,7 @@ function App() {
                     <ProtectedRoute>
                         <>
                             <Header />
-                            <div>Dashboard</div>
+                            <StudentDashboard />
                         </>
                     </ProtectedRoute>
                 } />

--- a/frontend/src/Journal.jsx
+++ b/frontend/src/Journal.jsx
@@ -157,10 +157,6 @@ function MoodEntriesPage() {
             return
         }
 
-        if (!selectedContent.trim()) {
-            setError("Please enter journal content")
-            return
-        }
 
         const formattedDate = `${selectedYear}-${selectedMonth}-${selectedDay}`
 

--- a/frontend/src/StudentDashboard.jsx
+++ b/frontend/src/StudentDashboard.jsx
@@ -1,0 +1,523 @@
+import { useEffect, useState } from "react"
+import apiCall from "./api/client"
+import "./styles/student-dashboard.css"
+import { FaGrinBeam, FaSmile, FaMeh, FaFrown, FaSadTear } from "react-icons/fa"
+
+const BG = "/background-faded-blue.avif"
+
+const MOODS = [
+  { icon: <FaGrinBeam />, value: 5 },
+  { icon: <FaSmile />, value: 4 },
+  { icon: <FaMeh />, value: 3 },
+  { icon: <FaFrown />, value: 2 },
+  { icon: <FaSadTear />, value: 1 },
+]
+
+function todayISODate() {
+  return new Date().toISOString().slice(0, 10)
+}
+
+function formatDueDateTime(value) {
+  if (!value) return "-"
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return String(value)
+  return d.toLocaleString([], {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  })
+}
+
+export default function StudentDashboard() {
+  const [personalLists, setPersonalLists] = useState([])
+  const [adminLists, setAdminLists] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState("")
+
+  const [selectedMood, setSelectedMood] = useState(null)
+  const [journalContent, setJournalContent] = useState("")
+  const [savingEntry, setSavingEntry] = useState(false)
+  const [entryMessage, setEntryMessage] = useState("")
+
+  const [selectedList, setSelectedList] = useState(null)
+  const [tasks, setTasks] = useState([])
+  const [loadingTasks, setLoadingTasks] = useState(false)
+
+  const [selectedTask, setSelectedTask] = useState(null)
+  const [savingTask, setSavingTask] = useState(false)
+  const [taskMessage, setTaskMessage] = useState("")
+
+  const [showAddTaskModal, setShowAddTaskModal] = useState(false)
+  const [addingTask, setAddingTask] = useState(false)
+  const [addTaskMessage, setAddTaskMessage] = useState("")
+  const [newTaskForm, setNewTaskForm] = useState({
+    title: "",
+    description: "",
+    due_date: "",
+    priority: "low",
+    status: "incomplete",
+  })
+
+  const [taskForm, setTaskForm] = useState({
+    title: "",
+    description: "",
+    due_date: "",
+    priority: "low",
+    status: "incomplete",
+  })
+
+  const isAssignedSelectedList = Boolean(selectedList?.assigned_by)
+
+  const toInputDateTime = (iso) => (iso ? String(iso).slice(0, 16) : "")
+
+  const getPriorityClass = (priority) => {
+    const p = String(priority || "low").toLowerCase()
+    if (p === "high") return "priority-high"
+    if (p === "medium") return "priority-medium"
+    return "priority-low"
+  }
+
+  const closeTaskEditor = () => {
+    setSelectedTask(null)
+    setTaskMessage("")
+  }
+
+  const pickTask = (task) => {
+    setSelectedTask(task)
+    setTaskMessage("")
+    setTaskForm({
+      title: task.title || "",
+      description: task.description || "",
+      due_date: toInputDateTime(task.due_date),
+      priority: task.priority || "low",
+      status: task.status || "incomplete",
+    })
+  }
+
+  useEffect(() => {
+    const loadLists = async () => {
+      setLoading(true)
+      setError("")
+      try {
+        const [personalRes, adminRes] = await Promise.all([
+          apiCall("/lists", { method: "GET" }),
+          apiCall("/lists/assigned", { method: "GET" }),
+        ])
+
+        const personalData = await personalRes.json()
+        const adminData = await adminRes.json()
+
+        if (!personalRes.ok) throw new Error(personalData.ERROR || "Failed to load personal lists")
+        if (!adminRes.ok) throw new Error(adminData.ERROR || "Failed to load admin lists")
+
+        setPersonalLists(Array.isArray(personalData) ? personalData : [])
+        setAdminLists(Array.isArray(adminData) ? adminData : [])
+      } catch (e) {
+        setError(e.message || "Failed to load dashboard")
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    loadLists()
+  }, [])
+
+  const loadTasksForList = async (list) => {
+    setSelectedList(list)
+    setSelectedTask(null)
+    setTaskMessage("")
+    setLoadingTasks(true)
+    setError("")
+    try {
+      const res = await apiCall(`/lists/${list.id}`, { method: "GET" })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.ERROR || "Failed to load tasks")
+
+      const nextTasks = Array.isArray(data?.tasks) ? data.tasks : Array.isArray(data) ? data : []
+      setTasks(nextTasks)
+    } catch (e) {
+      setTasks([])
+      setError(e.message || "Failed to load tasks")
+    } finally {
+      setLoadingTasks(false)
+    }
+  }
+
+  const handleUpdateTask = async () => {
+    if (!selectedList || !selectedTask) return
+    setSavingTask(true)
+    setTaskMessage("")
+    setError("")
+    try {
+      const payload = isAssignedSelectedList
+        ? { status: taskForm.status }
+        : {
+            title: taskForm.title,
+            description: taskForm.description,
+            due_date: taskForm.due_date || null,
+            priority: taskForm.priority,
+            status: taskForm.status,
+          }
+
+      const res = await apiCall(`/lists/${selectedList.id}/tasks/${selectedTask.id}`, {
+        method: "PUT",
+        body: JSON.stringify(payload),
+      })
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.ERROR || "Failed to update task")
+
+      await loadTasksForList(selectedList)
+      closeTaskEditor()
+    } catch (e) {
+      setTaskMessage(e.message || "Failed to update task")
+    } finally {
+      setSavingTask(false)
+    }
+  }
+
+  const handleTaskField = (field, value) => {
+    setTaskForm((prev) => ({ ...prev, [field]: value }))
+  }
+
+  const handleSaveJournal = async () => {
+    if (!selectedMood) {
+      setEntryMessage("Please select a mood.")
+      return
+    }
+
+    setSavingEntry(true)
+    setEntryMessage("")
+    try {
+      const res = await apiCall("/journal", {
+        method: "POST",
+        body: JSON.stringify({
+          date: todayISODate(),
+          mood: selectedMood.value,
+          content: journalContent.trim(),
+        }),
+      })
+
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.ERROR || "Failed to save journal entry")
+
+      setJournalContent("")
+      setEntryMessage("Journal entry saved.")
+    } catch (e) {
+      setEntryMessage(e.message || "Failed to save journal entry")
+    } finally {
+      setSavingEntry(false)
+    }
+  }
+
+  const handleMoodSelect = (mood) => {
+    setEntryMessage("")
+    setSelectedMood((prev) => {
+      const isSame = prev?.value === mood.value
+      if (isSame) {
+        setJournalContent("")
+        return null
+      }
+      return mood
+    })
+  }
+
+  const openAddTaskModal = () => {
+    if (!selectedList || isAssignedSelectedList) return
+    setAddTaskMessage("")
+    setNewTaskForm({
+      title: "",
+      description: "",
+      due_date: "",
+      priority: "low",
+      status: "incomplete",
+    })
+    setShowAddTaskModal(true)
+  }
+    const closeAddTaskModal = () => {
+    setShowAddTaskModal(false)
+    setAddTaskMessage("")
+  }
+
+  const handleNewTaskField = (field, value) => {
+    setNewTaskForm((prev) => ({ ...prev, [field]: value }))
+  }
+
+  const handleCreateTask = async () => {
+    if (!selectedList) return
+    if (!newTaskForm.title.trim()) {
+      setAddTaskMessage("Task title is required.")
+      return
+    }
+
+    setAddingTask(true)
+    setAddTaskMessage("")
+    try {
+      const res = await apiCall(`/lists/${selectedList.id}/tasks`, {
+        method: "POST",
+        body: JSON.stringify({
+          title: newTaskForm.title.trim(),
+          description: newTaskForm.description?.trim() || "",
+          due_date: newTaskForm.due_date || null,
+          priority: newTaskForm.priority,
+          status: newTaskForm.status,
+        }),
+      })
+
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.ERROR || "Failed to create task")
+
+      await loadTasksForList(selectedList)
+      closeAddTaskModal()
+    } catch (e) {
+      setAddTaskMessage(e.message || "Failed to create task")
+    } finally {
+      setAddingTask(false)
+    }
+  }
+
+  return (
+    <main className="sd-page" style={{ backgroundImage: `url(${BG})` }}>
+      <div className="sd-shell">
+        <div className="sd-header-top">Dashboard</div>
+
+        <section className="sd-card sd-mood-card">
+          <h2 className="sd-title">How are you feeling today?</h2>
+
+          <div className="sd-mood-row">
+            {MOODS.map((mood) => (
+              <button
+                key={mood.value}
+                type="button"
+                className={`sd-mood-btn ${selectedMood?.value === mood.value ? "is-active" : ""}`}
+                onClick={() => handleMoodSelect(mood)}
+                aria-label={`Mood ${mood.value}`}
+              >
+                <span className="sd-mood-icon">{mood.icon}</span>
+              </button>
+            ))}
+          </div>
+
+          {selectedMood && (
+            <div className="sd-journal">
+              <textarea
+                className="sd-input"
+                rows={4}
+                placeholder="Write a quick journal entry..."
+                value={journalContent}
+                onChange={(e) => setJournalContent(e.target.value)}
+              />
+              <button className="sd-btn" onClick={handleSaveJournal} disabled={savingEntry}>
+                {savingEntry ? "Saving..." : "Save Journal Entry"}
+              </button>
+              {entryMessage ? <p className="sd-note">{entryMessage}</p> : null}
+            </div>
+          )}
+        </section>
+
+        <section className="sd-grid">
+          <div className="sd-left-col">
+            <article className="sd-card">
+              <h3 className="sd-title">My Personal Lists</h3>
+              {loading ? (
+                <p className="sd-text">Loading...</p>
+              ) : personalLists.length === 0 ? (
+                <p className="sd-text">No personal lists yet.</p>
+              ) : (
+                <ul className="sd-list">
+                  {personalLists.map((list) => (
+                    <li key={list.id}>
+                      <button
+                        className={`sd-list-item-btn ${selectedList?.id === list.id ? "is-active" : ""}`}
+                        onClick={() => loadTasksForList(list)}
+                      >
+                        <strong>{list.name}</strong>
+                        <span>{list.description || "No description"}</span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </article>
+
+            <article className="sd-card">
+              <h3 className="sd-title">Lists from Admins</h3>
+              {loading ? (
+                <p className="sd-text">Loading...</p>
+              ) : adminLists.length === 0 ? (
+                <p className="sd-text">No admin-assigned lists.</p>
+              ) : (
+                <ul className="sd-list">
+                  {adminLists.map((list) => (
+                    <li key={list.id}>
+                      <button
+                        className={`sd-list-item-btn ${selectedList?.id === list.id ? "is-active" : ""}`}
+                        onClick={() => loadTasksForList(list)}
+                      >
+                        <strong>{list.name}</strong>
+                        <span>{list.description || "No description"}</span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </article>
+          </div>
+
+          <article className="sd-card">
+            <div className="sd-title-row">
+              <h3 className="sd-title">Tasks {selectedList ? `- ${selectedList.name}` : ""}</h3>
+              <button
+                type="button"
+                className="sd-btn"
+                onClick={openAddTaskModal}
+                disabled={!selectedList || isAssignedSelectedList}
+              >
+                + Add Task
+              </button>
+            </div>
+
+            {!selectedList ? (
+              <p className="sd-text">Select a list to view tasks.</p>
+            ) : loadingTasks ? (
+              <p className="sd-text">Loading tasks...</p>
+            ) : tasks.length === 0 ? (
+              <p className="sd-text">No tasks in this list.</p>
+            ) : (
+              <ul className="sd-task-list">
+                {tasks.map((task) => (
+                <li key={task.id}>
+                    <button
+                    className={`sd-task-item ${getPriorityClass(task.priority)} ${selectedTask?.id === task.id ? "is-active" : ""}`}
+                    onClick={() => pickTask(task)}
+                    >
+                    <strong>{task.title || task.name || "Task"}</strong>
+                    <span>{task.description || "No description"}</span>
+                    <span>Due: {formatDueDateTime(task.due_date)}</span>
+                    <span>Status: {task.status || "incomplete"}</span>
+                    </button>
+                </li>
+                ))}
+              </ul>
+            )}
+          </article>
+        </section>
+        {showAddTaskModal && (
+          <div className="sd-modal-overlay" onClick={closeAddTaskModal}>
+            <div className="sd-modal" onClick={(e) => e.stopPropagation()}>
+              <button className="sd-modal-close" type="button" onClick={closeAddTaskModal}>
+                ×
+              </button>
+
+              <h4 className="sd-title">Add Task</h4>
+
+              <input
+                className="sd-input"
+                value={newTaskForm.title}
+                onChange={(e) => handleNewTaskField("title", e.target.value)}
+                placeholder="Title"
+              />
+              <textarea
+                className="sd-input"
+                rows={3}
+                value={newTaskForm.description}
+                onChange={(e) => handleNewTaskField("description", e.target.value)}
+                placeholder="Description (optional)"
+              />
+              <input
+                className="sd-input"
+                type="datetime-local"
+                value={newTaskForm.due_date}
+                onChange={(e) => handleNewTaskField("due_date", e.target.value)}
+              />
+              <select
+                className="sd-input"
+                value={newTaskForm.priority}
+                onChange={(e) => handleNewTaskField("priority", e.target.value)}
+              >
+                <option value="low">low</option>
+                <option value="medium">medium</option>
+                <option value="high">high</option>
+              </select>
+              <select
+                className="sd-input"
+                value={newTaskForm.status}
+                onChange={(e) => handleNewTaskField("status", e.target.value)}
+              >
+                <option value="incomplete">incomplete</option>
+                <option value="in_progress">in_progress</option>
+                <option value="complete">complete</option>
+              </select>
+
+              <button className="sd-btn" type="button" onClick={handleCreateTask} disabled={addingTask}>
+                {addingTask ? "Saving..." : "Create Task"}
+              </button>
+              {addTaskMessage ? <p className="sd-note">{addTaskMessage}</p> : null}
+            </div>
+          </div>
+        )}
+        {selectedTask && (
+          <div className="sd-modal-overlay" onClick={closeTaskEditor}>
+            <div className="sd-modal" onClick={(e) => e.stopPropagation()}>
+              <button className="sd-modal-close" type="button" onClick={closeTaskEditor}>
+                ×
+              </button>
+
+              <h4 className="sd-title">Edit Task</h4>
+
+              <input
+                className="sd-input"
+                value={taskForm.title}
+                onChange={(e) => handleTaskField("title", e.target.value)}
+                disabled={isAssignedSelectedList}
+                placeholder="Title"
+              />
+              <textarea
+                className="sd-input"
+                rows={3}
+                value={taskForm.description}
+                onChange={(e) => handleTaskField("description", e.target.value)}
+                disabled={isAssignedSelectedList}
+                placeholder="Description"
+              />
+              <input
+                className="sd-input"
+                type="datetime-local"
+                value={taskForm.due_date}
+                onChange={(e) => handleTaskField("due_date", e.target.value)}
+                disabled={isAssignedSelectedList}
+              />
+              <select
+                className="sd-input"
+                value={taskForm.priority}
+                onChange={(e) => handleTaskField("priority", e.target.value)}
+                disabled={isAssignedSelectedList}
+              >
+                <option value="low">low</option>
+                <option value="medium">medium</option>
+                <option value="high">high</option>
+              </select>
+              <select
+                className="sd-input"
+                value={taskForm.status}
+                onChange={(e) => handleTaskField("status", e.target.value)}
+              >
+                <option value="incomplete">incomplete</option>
+                <option value="in_progress">in_progress</option>
+                <option value="complete">complete</option>
+              </select>
+
+              <button className="sd-btn" type="button" onClick={handleUpdateTask} disabled={savingTask}>
+                {savingTask ? "Saving..." : "Save Task"}
+              </button>
+              {taskMessage ? <p className="sd-note">{taskMessage}</p> : null}
+            </div>
+          </div>
+        )}
+
+        {error ? <p className="sd-error">{error}</p> : null}
+      </div>
+    </main>
+  )
+}

--- a/frontend/src/StudentDashboard.jsx
+++ b/frontend/src/StudentDashboard.jsx
@@ -60,6 +60,14 @@ export default function StudentDashboard() {
     status: "incomplete",
   })
 
+  const [showAddListModal, setShowAddListModal] = useState(false)
+  const [addingList, setAddingList] = useState(false)
+  const [addListMessage, setAddListMessage] = useState("")
+  const [newListForm, setNewListForm] = useState({
+    name: "",
+    description: "",
+  })
+
   const [taskForm, setTaskForm] = useState({
     title: "",
     description: "",
@@ -79,48 +87,37 @@ export default function StudentDashboard() {
     return "priority-low"
   }
 
-  const closeTaskEditor = () => {
-    setSelectedTask(null)
-    setTaskMessage("")
-  }
+  const loadLists = async () => {
+    setLoading(true)
+    setError("")
+    try {
+      const [personalRes, adminRes] = await Promise.all([
+        apiCall("/lists", { method: "GET" }),
+        apiCall("/lists/assigned", { method: "GET" }),
+      ])
 
-  const pickTask = (task) => {
-    setSelectedTask(task)
-    setTaskMessage("")
-    setTaskForm({
-      title: task.title || "",
-      description: task.description || "",
-      due_date: toInputDateTime(task.due_date),
-      priority: task.priority || "low",
-      status: task.status || "incomplete",
-    })
+      const personalData = await personalRes.json()
+      const adminData = await adminRes.json()
+
+      if (!personalRes.ok) throw new Error(personalData.ERROR || "Failed to load personal lists")
+      if (!adminRes.ok) throw new Error(adminData.ERROR || "Failed to load admin lists")
+
+      const allPersonal = Array.isArray(personalData) ? personalData : []
+      const assigned = Array.isArray(adminData) ? adminData : []
+
+      const assignedIds = new Set(assigned.map((l) => l.id))
+      const personalOnly = allPersonal.filter((l) => !assignedIds.has(l.id))
+
+      setPersonalLists(personalOnly)
+      setAdminLists(assigned)
+    } catch (e) {
+      setError(e.message || "Failed to load dashboard")
+    } finally {
+      setLoading(false)
+    }
   }
 
   useEffect(() => {
-    const loadLists = async () => {
-      setLoading(true)
-      setError("")
-      try {
-        const [personalRes, adminRes] = await Promise.all([
-          apiCall("/lists", { method: "GET" }),
-          apiCall("/lists/assigned", { method: "GET" }),
-        ])
-
-        const personalData = await personalRes.json()
-        const adminData = await adminRes.json()
-
-        if (!personalRes.ok) throw new Error(personalData.ERROR || "Failed to load personal lists")
-        if (!adminRes.ok) throw new Error(adminData.ERROR || "Failed to load admin lists")
-
-        setPersonalLists(Array.isArray(personalData) ? personalData : [])
-        setAdminLists(Array.isArray(adminData) ? adminData : [])
-      } catch (e) {
-        setError(e.message || "Failed to load dashboard")
-      } finally {
-        setLoading(false)
-      }
-    }
-
     loadLists()
   }, [])
 
@@ -143,6 +140,23 @@ export default function StudentDashboard() {
     } finally {
       setLoadingTasks(false)
     }
+  }
+
+  const closeTaskEditor = () => {
+    setSelectedTask(null)
+    setTaskMessage("")
+  }
+
+  const pickTask = (task) => {
+    setSelectedTask(task)
+    setTaskMessage("")
+    setTaskForm({
+      title: task.title || "",
+      description: task.description || "",
+      due_date: toInputDateTime(task.due_date),
+      priority: task.priority || "low",
+      status: task.status || "incomplete",
+    })
   }
 
   const handleUpdateTask = async () => {
@@ -235,7 +249,8 @@ export default function StudentDashboard() {
     })
     setShowAddTaskModal(true)
   }
-    const closeAddTaskModal = () => {
+
+  const closeAddTaskModal = () => {
     setShowAddTaskModal(false)
     setAddTaskMessage("")
   }
@@ -274,6 +289,50 @@ export default function StudentDashboard() {
       setAddTaskMessage(e.message || "Failed to create task")
     } finally {
       setAddingTask(false)
+    }
+  }
+
+  const openAddListModal = () => {
+    setAddListMessage("")
+    setNewListForm({ name: "", description: "" })
+    setShowAddListModal(true)
+  }
+
+  const closeAddListModal = () => {
+    setShowAddListModal(false)
+    setAddListMessage("")
+  }
+
+  const handleListField = (field, value) => {
+    setNewListForm((prev) => ({ ...prev, [field]: value }))
+  }
+
+  const handleCreateList = async () => {
+    if (!newListForm.name.trim()) {
+      setAddListMessage("List name is required.")
+      return
+    }
+
+    setAddingList(true)
+    setAddListMessage("")
+    try {
+      const res = await apiCall("/lists", {
+        method: "POST",
+        body: JSON.stringify({
+          name: newListForm.name.trim(),
+          description: newListForm.description?.trim() || "",
+        }),
+      })
+
+      const data = await res.json()
+      if (!res.ok) throw new Error(data.ERROR || "Failed to create list")
+
+      await loadLists()
+      closeAddListModal()
+    } catch (e) {
+      setAddListMessage(e.message || "Failed to create list")
+    } finally {
+      setAddingList(false)
     }
   }
 
@@ -319,7 +378,13 @@ export default function StudentDashboard() {
         <section className="sd-grid">
           <div className="sd-left-col">
             <article className="sd-card">
-              <h3 className="sd-title">My Personal Lists</h3>
+              <div className="sd-title-row">
+                <h3 className="sd-title">My Personal Lists</h3>
+                <button type="button" className="sd-btn" onClick={openAddListModal}>
+                  + Add List
+                </button>
+              </div>
+
               {loading ? (
                 <p className="sd-text">Loading...</p>
               ) : personalLists.length === 0 ? (
@@ -387,22 +452,54 @@ export default function StudentDashboard() {
             ) : (
               <ul className="sd-task-list">
                 {tasks.map((task) => (
-                <li key={task.id}>
+                  <li key={task.id}>
                     <button
-                    className={`sd-task-item ${getPriorityClass(task.priority)} ${selectedTask?.id === task.id ? "is-active" : ""}`}
-                    onClick={() => pickTask(task)}
+                      className={`sd-task-item ${getPriorityClass(task.priority)} ${selectedTask?.id === task.id ? "is-active" : ""}`}
+                      onClick={() => pickTask(task)}
                     >
-                    <strong>{task.title || task.name || "Task"}</strong>
-                    <span>{task.description || "No description"}</span>
-                    <span>Due: {formatDueDateTime(task.due_date)}</span>
-                    <span>Status: {task.status || "incomplete"}</span>
+                      <strong>{task.title || task.name || "Task"}</strong>
+                      <span>{task.description || "No description"}</span>
+                      <span>Due: {formatDueDateTime(task.due_date)}</span>
+                      <span>Status: {task.status || "incomplete"}</span>
                     </button>
-                </li>
+                  </li>
                 ))}
               </ul>
             )}
           </article>
         </section>
+
+        {showAddListModal && (
+          <div className="sd-modal-overlay" onClick={closeAddListModal}>
+            <div className="sd-modal" onClick={(e) => e.stopPropagation()}>
+              <button className="sd-modal-close" type="button" onClick={closeAddListModal}>
+                ×
+              </button>
+
+              <h4 className="sd-title">Add Personal List</h4>
+
+              <input
+                className="sd-input"
+                value={newListForm.name}
+                onChange={(e) => handleListField("name", e.target.value)}
+                placeholder="List name"
+              />
+              <textarea
+                className="sd-input"
+                rows={3}
+                value={newListForm.description}
+                onChange={(e) => handleListField("description", e.target.value)}
+                placeholder="Description (optional)"
+              />
+
+              <button className="sd-btn" type="button" onClick={handleCreateList} disabled={addingList}>
+                {addingList ? "Saving..." : "Create List"}
+              </button>
+              {addListMessage ? <p className="sd-note">{addListMessage}</p> : null}
+            </div>
+          </div>
+        )}
+
         {showAddTaskModal && (
           <div className="sd-modal-overlay" onClick={closeAddTaskModal}>
             <div className="sd-modal" onClick={(e) => e.stopPropagation()}>
@@ -457,6 +554,7 @@ export default function StudentDashboard() {
             </div>
           </div>
         )}
+
         {selectedTask && (
           <div className="sd-modal-overlay" onClick={closeTaskEditor}>
             <div className="sd-modal" onClick={(e) => e.stopPropagation()}>

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -10,40 +10,39 @@ function Header() {
 
     const SHARK = "/shark.png"
 
-    const [username] = useState(() => {
+    const [userInfo] = useState(() => {
         const savedUser = localStorage.getItem("user")
-        if (!savedUser) return "User"
+        if (!savedUser) return { username: "User", role: "" }
 
         try {
             const parsedUser = JSON.parse(savedUser)
-            return parsedUser.username || "User"
+            return {
+                username: parsedUser.username || "User",
+                role: String(parsedUser.role || "").toLowerCase(),
+            }
         } catch {
-            return "User"
+            return { username: "User", role: "" }
         }
     })
+
+    const dashboardPath = userInfo.role === "admin" ? "/admin/dashboard" : "/dashboard"
 
     const handleLogout = () => {
         localStorage.removeItem("token")
         localStorage.removeItem("user")
-
-        navigate("/") 
+        navigate("/")
     }
 
     return (
         <>
             <header className="app-header">
                 <div className="header-left">
-                    <button
-                        className="hamburger"
-                        onClick={() => setOpen(!open)}
-                    >
+                    <button className="hamburger" onClick={() => setOpen(!open)}>
                         ☰
                     </button>
 
-                    <Link to="/dashboard" className="header-title">
-                        <h1 className="header-title">
-                            Welcome, {username}
-                        </h1>
+                    <Link to={dashboardPath} className="header-title">
+                        <h1 className="header-title">Welcome, {userInfo.username}</h1>
                     </Link>
                 </div>
 
@@ -57,9 +56,7 @@ function Header() {
 
                     {showMenu && (
                         <div className="profile-dropdown">
-                            <button onClick={handleLogout}>
-                                Logout
-                            </button>
+                            <button onClick={handleLogout}>Logout</button>
                         </div>
                     )}
                 </div>

--- a/frontend/src/components/Navigation.jsx
+++ b/frontend/src/components/Navigation.jsx
@@ -2,20 +2,39 @@ import { Link } from "react-router-dom"
 import "./header.css"
 
 function NavSidebar({ open, setOpen }) {
+    const savedUser = localStorage.getItem("user")
+    let role = ""
+    try {
+        role = String(JSON.parse(savedUser || "{}")?.role || "").toLowerCase()
+    } catch {
+        role = ""
+    }
+
+    const isAdmin = role === "admin"
+
     return (
         <div className={`sidebar ${open ? "open" : ""}`}>
-            <button 
-                className="close-btn"
-                onClick={() => setOpen(false)}
-            >
+            <button className="close-btn" onClick={() => setOpen(false)}>
                 ✕
             </button>
 
             <nav className="nav-links">
-                <Link to="/dashboard" onClick={() => setOpen(false)}>Dashboard</Link>
-                <Link to="/journal" onClick={() => setOpen(false)}>Journal</Link>
-                <Link to="/lists" onClick={() => setOpen(false)}>Lists</Link>
-                <Link to="/reminders" onClick={() => setOpen(false)}>Reminders</Link>
+                {isAdmin ? (
+                    <>
+                        <Link to="/admin/dashboard" onClick={() => setOpen(false)}>Dashboard</Link>
+                        <Link to="/admin/tasks" onClick={() => setOpen(false)}>Assigned Tasks</Link>
+                        <Link to="/admin/reminders" onClick={() => setOpen(false)}>Sent Reminders</Link>
+                        <Link to="/admin/students" onClick={() => setOpen(false)}>Manage Users</Link>
+                        <Link to="/admin/lists" onClick={() => setOpen(false)}>My Lists</Link>
+                    </>
+                ) : (
+                    <>
+                        <Link to="/dashboard" onClick={() => setOpen(false)}>Dashboard</Link>
+                        <Link to="/journal" onClick={() => setOpen(false)}>Journal</Link>
+                        <Link to="/lists" onClick={() => setOpen(false)}>Lists</Link>
+                        <Link to="/reminders" onClick={() => setOpen(false)}>Reminders</Link>
+                    </>
+                )}
             </nav>
         </div>
     )

--- a/frontend/src/styles/admin-dashboard.css
+++ b/frontend/src/styles/admin-dashboard.css
@@ -1,0 +1,182 @@
+.ad-page {
+  min-height: 100vh;
+  background-size: cover;
+  background-position: center;
+  padding: 40px 20px;
+  display: flex;
+  justify-content: center;
+}
+
+.ad-shell {
+  width: 100%;
+  max-width: 1100px;
+}
+
+.ad-header {
+  color: #fff;
+  font-size: 2rem;
+  margin-bottom: 12px;
+}
+
+.ad-nav {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.ad-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+}
+
+.ad-card {
+  background: rgba(10, 40, 80, 0.55);
+  border: 2px solid rgba(100, 200, 255, 0.25);
+  border-radius: 14px;
+  padding: 14px;
+}
+
+.ad-card-title {
+  color: #dff4ff;
+  text-decoration: none;
+  font-weight: 700;
+  display: inline-block;
+  margin-bottom: 10px;
+}
+
+.ad-form {
+  display: grid;
+  gap: 8px;
+}
+
+.ad-input {
+  background: rgba(180, 220, 255, 0.12);
+  border: 1px solid rgba(100, 200, 255, 0.35);
+  color: #dff4ff;
+  border-radius: 10px;
+  padding: 10px;
+}
+
+.ad-btn {
+  width: fit-content;
+  border: 1px solid rgba(100, 200, 255, 0.45);
+  border-radius: 8px;
+  background: rgba(80, 180, 255, 0.22);
+  color: #e6f6ff;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.ad-msg {
+  margin-top: 10px;
+  color: #dff4ff;
+}
+
+.ad-target-row {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.ad-student-checklist {
+  max-height: 140px;
+  overflow: auto;
+  border: 1px solid rgba(100, 200, 255, 0.25);
+  border-radius: 10px;
+  padding: 8px;
+  display: grid;
+  gap: 6px;
+}
+
+select.ad-input {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background: rgba(10, 40, 80, 0.85);
+  color: #dff4ff;
+  border: 1px solid rgba(100, 200, 255, 0.35);
+  padding-right: 2rem;
+  background-image:
+    linear-gradient(45deg, transparent 50%, #dff4ff 50%),
+    linear-gradient(135deg, #dff4ff 50%, transparent 50%);
+  background-position:
+    calc(100% - 16px) calc(50% - 3px),
+    calc(100% - 10px) calc(50% - 3px);
+  background-size: 6px 6px, 6px 6px;
+  background-repeat: no-repeat;
+}
+
+select.ad-input option {
+  background-color: #0d2e52;
+  color: #dff4ff;
+}
+
+select.ad-input:focus,
+.ad-input:focus {
+  outline: none;
+  border-color: rgba(130, 210, 255, 0.8);
+  box-shadow: 0 0 0 2px rgba(100, 200, 255, 0.2);
+}
+
+.ad-target-row label,
+.ad-student-checklist label {
+  color: #e6f6ff;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 500;
+}
+
+/* radio + checkbox theme */
+.ad-target-row input[type="radio"],
+.ad-student-checklist input[type="checkbox"] {
+  accent-color: #7fd3ff;
+  width: 16px;
+  height: 16px;
+  cursor: pointer;
+}
+
+/* make checklist container match card style better */
+.ad-student-checklist {
+  background: rgba(10, 40, 80, 0.35);
+  color: #e6f6ff;
+}
+
+.ad-student-checklist label {
+  padding: 4px 2px;
+}
+
+.ad-grid-single {
+  grid-template-columns: 1fr;
+  margin-top: 12px;
+}
+
+.ad-students-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.ad-student-item {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px;
+  border: 1px solid rgba(100, 200, 255, 0.25);
+  border-radius: 10px;
+  background: rgba(170, 220, 255, 0.08);
+  color: #e6f6ff;
+}
+
+.ad-student-item span {
+  opacity: 0.95;
+}
+
+@media (max-width: 900px) {
+  .ad-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/styles/admin-students.css
+++ b/frontend/src/styles/admin-students.css
@@ -1,0 +1,93 @@
+.as-page {
+  min-height: 100vh;
+  background-size: cover;
+  background-position: center;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 40px 20px;
+}
+
+.as-shell {
+  width: 100%;
+  max-width: 1100px;
+}
+
+.as-header-top {
+  color: white;
+  font-size: 2.5rem;
+  margin-bottom: 14px;
+}
+
+.as-card {
+  background: rgba(10, 40, 80, 0.5);
+  border: 2px solid rgba(100, 200, 255, 0.25);
+  border-radius: 16px;
+  backdrop-filter: blur(3px);
+  padding: 16px;
+  color: #d0eeff;
+}
+
+.as-search-row {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.as-input {
+  width: 100%;
+  background: rgba(180, 220, 255, 0.12);
+  border: 1px solid rgba(100, 200, 255, 0.35);
+  border-radius: 10px;
+  color: #e6f6ff;
+  padding: 10px;
+}
+
+.as-btn {
+  border: 1px solid rgba(100, 200, 255, 0.45);
+  border-radius: 8px;
+  background: rgba(80, 180, 255, 0.22);
+  color: #e6f6ff;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.as-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.as-item {
+  border: 1px solid rgba(100, 200, 255, 0.25);
+  border-radius: 10px;
+  padding: 10px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: rgba(170, 220, 255, 0.08);
+}
+
+.as-sub {
+  font-size: 0.85rem;
+  opacity: 0.9;
+}
+
+.as-badge {
+  border: 1px solid rgba(130, 210, 255, 0.8);
+  background: rgba(100, 200, 255, 0.2);
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 0.8rem;
+}
+
+.as-note {
+  margin: 8px 0;
+}
+
+.as-btn-danger {
+  border-color: rgba(255, 120, 120, 0.55);
+  background: rgba(255, 80, 80, 0.2);
+}

--- a/frontend/src/styles/student-dashboard.css
+++ b/frontend/src/styles/student-dashboard.css
@@ -1,0 +1,275 @@
+.sd-page {
+  min-height: 100vh;
+  background-size: cover;
+  background-position: center;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  padding: 40px 20px;
+}
+
+.sd-shell {
+  width: 100%;
+  max-width: 1100px;
+}
+
+.sd-header-top {
+  color: white;
+  font-size: 2.5rem;
+  margin-bottom: 14px;
+}
+
+.sd-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+.sd-card {
+  background: rgba(10, 40, 80, 0.5);
+  border: 2px solid rgba(100, 200, 255, 0.25);
+  border-radius: 16px;
+  backdrop-filter: blur(3px);
+  padding: 16px;
+  color: #d0eeff;
+  margin-bottom: 16px;
+}
+
+.sd-title {
+  margin: 0 0 12px;
+  color: #e6f6ff;
+}
+
+.sd-mood-card {
+  min-height: 260px;
+  display: flex;
+  flex-direction: column;
+}
+
+.sd-mood-row {
+  flex: 1;
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.sd-mood-btn {
+  width: 100%;
+  min-height: 110px;
+  border: 1px solid rgba(100, 200, 255, 0.35);
+  background: rgba(170, 220, 255, 0.1);
+  color: #e6f6ff;
+  border-radius: 10px;
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.sd-mood-icon {
+  font-size: 2rem;
+}
+
+.sd-mood-btn.is-active {
+  background: rgba(100, 200, 255, 0.28);
+  border-color: rgba(150, 220, 255, 0.9);
+}
+
+.sd-journal {
+  display: grid;
+  gap: 8px;
+}
+
+.sd-input {
+  width: 100%;
+  resize: vertical;
+  background: rgba(180, 220, 255, 0.12);
+  border: 1px solid rgba(100, 200, 255, 0.35);
+  border-radius: 10px;
+  color: #e6f6ff;
+  padding: 10px;
+}
+
+.sd-btn {
+  width: fit-content;
+  border: 1px solid rgba(100, 200, 255, 0.45);
+  border-radius: 8px;
+  background: rgba(80, 180, 255, 0.22);
+  color: #e6f6ff;
+  padding: 8px 12px;
+  cursor: pointer;
+}
+
+.sd-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.sd-list li {
+  border: 1px solid rgba(100, 200, 255, 0.25);
+  border-radius: 10px;
+  padding: 10px;
+  display: grid;
+  gap: 6px;
+  background: rgba(170, 220, 255, 0.08);
+}
+
+.sd-text,
+.sd-note,
+.sd-error {
+  margin: 0;
+}
+
+.sd-error {
+  color: #ffbcbc;
+}
+
+.sd-left-col {
+  display: grid;
+  gap: 16px;
+}
+
+.sd-list-item-btn {
+  width: 100%;
+  text-align: left;
+  border: 1px solid rgba(100, 200, 255, 0.25);
+  border-radius: 10px;
+  padding: 10px;
+  display: grid;
+  gap: 6px;
+  background: rgba(170, 220, 255, 0.08);
+  color: #d0eeff;
+  cursor: pointer;
+  font: inherit;
+}
+
+.sd-list-item-btn.is-active {
+  border-color: rgba(150, 220, 255, 0.9);
+  background: rgba(100, 200, 255, 0.2);
+}
+
+.sd-list-item-btn strong,
+.sd-list-item-btn span {
+  pointer-events: none;
+}
+
+.sd-task-list {
+  list-style: none;
+  margin: 0 0 12px 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.sd-task-item {
+  width: 100%;
+  text-align: left;
+  border: 1px solid rgba(100, 200, 255, 0.25);
+  border-left: 6px solid transparent;
+  border-radius: 10px;
+  padding: 10px;
+  display: grid;
+  gap: 6px;
+  background: rgba(170, 220, 255, 0.08);
+  color: #d0eeff;
+  cursor: pointer;
+  font: inherit;
+}
+
+.sd-task-item.is-active {
+  border-color: rgba(150, 220, 255, 0.9);
+  box-shadow: 0 0 0 1px rgba(150, 220, 255, 0.35) inset;
+}
+
+.sd-task-item.priority-high { border-left-color: #ff7b7b; }
+.sd-task-item.priority-medium { border-left-color: #ffd36b; }
+.sd-task-item.priority-low { border-left-color: #75e3a3; }
+
+.sd-task-editor {
+  margin-top: 10px;
+  display: grid;
+  gap: 8px;
+  border-top: 1px solid rgba(100, 200, 255, 0.2);
+  padding-top: 10px;
+}
+
+.sd-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 20, 40, 0.65);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 16px;
+}
+
+.sd-modal {
+  width: min(560px, 100%);
+  max-height: 90vh;
+  overflow-y: auto;
+  background: rgba(10, 40, 80, 0.95);
+  border: 2px solid rgba(100, 200, 255, 0.35);
+  border-radius: 14px;
+  padding: 14px;
+  display: grid;
+  gap: 8px;
+  position: relative;
+}
+
+.sd-modal-close {
+  position: absolute;
+  right: 8px;
+  top: 6px;
+  border: none;
+  background: transparent;
+  color: #d0eeff;
+  font-size: 22px;
+  cursor: pointer;
+}
+
+select.sd-input {
+  background: rgba(10, 40, 80, 0.85);
+  color: #d0eeff;
+  border: 1px solid rgba(100, 200, 255, 0.35);
+}
+
+select.sd-input option {
+  background-color: #0d2e52;
+  color: #d0eeff;
+}
+
+select.sd-input:focus {
+  outline: none;
+  border-color: rgba(130, 210, 255, 0.8);
+  box-shadow: 0 0 0 2px rgba(100, 200, 255, 0.2);
+}
+
+.sd-title-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.sd-title-row .sd-title {
+  margin: 0;
+}
+
+@media (max-width: 900px) {
+  .sd-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 900px) {
+  .sd-mood-row {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}


### PR DESCRIPTION
User Dashboard: users can see their personal and admin lists as well as a quick journal entry for the day
Admin Dashboard: admins can see all their students and quickly assign tasks/reminders to a number of their assigned students
Navigation: Users and Admins have different navigation options.
     - Admins -> Dashboard, Tasks they have assigned, Reminders they have sent, Manage Users, their own lists. I didn't think a journal was necessary for admins but I kept the list page because that seems useful for admins to have, probably should add a page where they can just view users as well
     - Users -> Dashboard, Lists, Journal, Reminders
seed.py: A seeding script to populate db with 2 admins and 10 users. Will override current db.
Backend: task and reminder assigning support multiple users and the same time. Admins do not share users so they can manage what users they look over, also helps with users having multiple admins.